### PR TITLE
bracket constructor syntax for set does not exist in python < 2.7

### DIFF
--- a/uncertainties/core.py
+++ b/uncertainties/core.py
@@ -2836,7 +2836,7 @@ def parse_error_in_parentheses(representation):
         uncert_int = '1'  # The other parts of the uncertainty are None
 
     # Do we have a fully explicit uncertainty?
-    if uncert_dec is not None or uncert in {'nan', 'NAN', 'inf', 'INF'}:
+    if uncert_dec is not None or uncert in set(['nan', 'NAN', 'inf', 'INF']):
         uncert_value = float(uncert)
     else:
         # uncert_int represents an uncertainty on the last digits:


### PR DESCRIPTION
We want to use uncertainties with a package that will sometimes be installed on python2.6.  This was the only line of code that prevented compiling and installing the uncertainties package.