### PR TITLE
Updating Travis CI setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ MANIFEST
 uncertainties.egg-info/
 # For PyCharm (contains project files):
 .idea/
+.cache
+.*.swp

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,39 +1,28 @@
 # Config file for automatic testing at travis-ci.org
-
 language: python
-
-python:
-    # Travis does not have Python 2.4 and 2.5:
-    # - 2.4
-    # - 2.5
-    - 2.6
-    - 2.7
-    - 3.2
-    - 3.3
-    # Travis does not yet have Python 3.4:
-    # - 3.4
+sudo: false # use the new faster dockerized containers on Travis CI
 
 matrix:
+    include:
+    # A the moment PY2.6 fails due to the use of dictionary comprehension
+    # not sure if we want to support it
+    #- python: "2.6"
+    #  env: DEPS="numpy==1.8 nose"
+    - python: "2.7"
+      env: DEPS="numpy==1.9 nose"
+    - python: "3.3"
+      env: DEPS="numpy==1.9 nose"
+    - python: "3.4"
+      env: DEPS="numpy==1.11 nose"
+    - python: "3.5"
+      env: DEPS="numpy==1.11 nose"
 
-env:
 
-# !!! Is wheel necessary?
-
-# command to install dependencies
 before_install:
-    # Install the pip that supports wheel
     - pip install setuptools --upgrade
     - pip install pip --upgrade
-    - pip install wheel --upgrade
-    
-    #- sudo apt-get install python-numpy cython libatlas-dev liblapack-dev gfortran
-    - sudo apt-get update
+    - pip install $DEPS
 
-# !!! Is astropy/wheel necessary??
-install:    
-    - pip install --find-links http://wheels2.astropy.org/ --use-wheel --use-mirrors --upgrade "numpy==1.8.0"
-
- # command to run tests
 script:
     - python setup.py egg_info
     - python setup.py nosetests -sv

--- a/README.rst
+++ b/README.rst
@@ -1,9 +1,9 @@
 uncertainties
 =============
 
-..
-    .. image:: https://travis-ci.org/lebigot/uncertainties.png
-       :target: https://travis-ci.org/lebigot/uncertainties
+
+.. image:: https://travis-ci.org/lebigot/uncertainties.png
+   :target: https://travis-ci.org/lebigot/uncertainties
 
 This is the uncertainties Python package, which performs transparent
 calculations with uncertainties (aka "error propagation"). This package


### PR DESCRIPTION
This partially addresses issue #61 ,

-  fixes and updates the `.travis.yml`: The [tests pass](https://travis-ci.org/rth/uncertainties) on Python 2.7, 3.3, 3.4, 3.5 and for different numpy versions. For 2.6 tests fail with the current code base due to the use of dictionary comprehension in core.py (line 947), not sure if you want to support 2.6 (I would have dropped it as discussed in issue #56, also relevant to issue #52 ). The 3.2 is not tested (as running an exhaustive testing of all versions might take too long), but it could be added.

- Un-comments the Travis-CI badge in the Readme

Please let me know your feedback on this..