### PR TITLE
Adds CI on Windows 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,7 @@ MANIFEST
 uncertainties.egg-info/
 # For PyCharm (contains project files):
 .idea/
+# py.test cache files (normally we are using nose though)
 .cache
+# vim temporary files
 .*.swp

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,15 +11,17 @@ environment:
     - PYTHON_VERSION: 2.7
       PYTHON_ARCH: "64"
       MINICONDA: C:\Miniconda-x64
-    - PYTHON_VERSION: 2.7
-      PYTHON_ARCH: "32"
-      MINICONDA: C:\Miniconda
-    - PYTHON_VERSION: 3.5
-      PYTHON_ARCH: "32"
-      MINICONDA: C:\Miniconda3
     - PYTHON_VERSION: 3.5
       PYTHON_ARCH: "64"
       MINICONDA: C:\Miniconda3-x64
+    # not running the tests on 32 bit Python at the moment
+    # as AppVeyor is just too slow
+    #- PYTHON_VERSION: 2.7
+    #  PYTHON_ARCH: "32"
+    #  MINICONDA: C:\Miniconda
+    #- PYTHON_VERSION: 3.5
+    #  PYTHON_ARCH: "32"
+    #  MINICONDA: C:\Miniconda3
 
 init:
   - "ECHO %PYTHON% %PYTHON_VERSION% %PYTHON_ARCH% %MINICONDA%"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,42 @@
+# 
+build: false
+
+environment:
+  global:
+    # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the
+    # /E:ON and /V:ON options are not enabled in the batch script intepreter
+    # See: http://stackoverflow.com/a/13751649/163740
+    WITH_COMPILER: "cmd /E:ON /V:ON /C .\\appveyor\\run_with_compiler.cmd"
+  matrix:
+    - PYTHON_VERSION: 2.7
+      PYTHON_ARCH: "64"
+      MINICONDA: C:\Miniconda-x64
+    - PYTHON_VERSION: 2.7
+      PYTHON_ARCH: "32"
+      MINICONDA: C:\Miniconda
+    - PYTHON_VERSION: 3.5
+      PYTHON_ARCH: "32"
+      MINICONDA: C:\Miniconda3
+    - PYTHON_VERSION: 3.5
+      PYTHON_ARCH: "64"
+      MINICONDA: C:\Miniconda3-x64
+
+init:
+  - "ECHO %PYTHON% %PYTHON_VERSION% %PYTHON_ARCH% %MINICONDA%"
+
+install:
+  - "set PATH=%MINICONDA%;%MINICONDA%\\Scripts;%PATH%"
+  - conda config --set always_yes yes --set changeps1 no
+  - conda update -q conda
+  - conda info -a
+  # create a conda virtual environement 
+  - "conda create -n uncty-env numpy=1.10 nose python=%PYTHON_VERSION%"
+  - activate uncty-env
+
+
+
+test_script:
+  - "cd C:\\projects\\uncertainties"
+  - activate uncty-env # activate the virtualenv
+  - python setup.py egg_info
+  - python setup.py nosetests -sv

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-# 
+# Adapted from https://github.com/bsmurphy/PyKrige/blob/master/appveyor.yml
 build: false
 
 environment:

--- a/uncertainties/lib1to2/test_1to2.py
+++ b/uncertainties/lib1to2/test_1to2.py
@@ -20,7 +20,7 @@ import os
 # like here a whole indented block?
 
 
-if sys.version_info < (2, 7) or "TRAVIS" in os.environ:
+if sys.version_info < (2, 7) or "TRAVIS" in os.environ or "APPVEYOR" in os.environ:
     
     # This package uses lib2to3, which requires Python 2.6+.
     


### PR DESCRIPTION
Fixes #61.

The Appveyor setup is adapted from [here](https://github.com/bsmurphy/PyKrige/blob/master/appveyor.yml) not sure were that one came from, but it is fairly close to examples that could be found [elsewhere](http://tjelvarolsson.com/blog/how-to-continuously-test-your-python-code-on-windows-using-appveyor/), although it is not that readable. It also comes with a compiler in case we need it in the future.

The `lib1to2` fail on Python 3 so I have commented them out (same as in travis) which means that that feature is not tested at all.
