### PR TITLE
Fixes massive FORK ME overlay

### DIFF
--- a/doc/_templates/layout.html
+++ b/doc/_templates/layout.html
@@ -6,7 +6,7 @@
 
 {% block document %}
 {{ super() }}
-<a href="https://github.com/you"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/652c5b9acfaddf3a9c326fa6bde407b87f7be0f4/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6f72616e67655f6666373630302e706e67" alt="Fork me on GitHub" height="120 %" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_orange_ff7600.png"></a>
+<a href="https://github.com/you"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/652c5b9acfaddf3a9c326fa6bde407b87f7be0f4/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6f72616e67655f6666373630302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_orange_ff7600.png"></a>
 {% endblock %}
 
 {% block relbar1 %}

--- a/doc/_templates/layout.html
+++ b/doc/_templates/layout.html
@@ -11,7 +11,7 @@
 
 {% block relbar1 %}
 
-<div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">
+<div style="background-color: white; text-align: left; padding: 30px 15px 20px 15px">
 <a href="{{ pathto('index') }}"><img src="{{
 pathto("_static/logo.png", 1) }}" border="0" alt="uncertainties"/></a>
 </div>


### PR DESCRIPTION
The FORK ME image is about 50% of the width of the page on firefox on linux at 1080p. This fixes it.

Example screenshot: 
![screenshot_20180307_095440](https://user-images.githubusercontent.com/167164/37063491-a9c56bc2-21ed-11e8-8452-faadbb1ba96d.png)
