### PR TITLE
Use getfullargspec, fix #60

### DIFF
--- a/uncertainties/core.py
+++ b/uncertainties/core.py
@@ -31,6 +31,11 @@ import inspect
 import numbers
 import collections
 
+if sys.version_info < (3,):
+    from inspect import getargspec
+else:
+    from inspect import getfullargspec as getargspec
+
 # Attributes that are always exported (some other attributes are
 # exported only if the NumPy module is available...):
 __all__ = [
@@ -531,7 +536,7 @@ def wrap(f, derivatives_args=[], derivatives_kwargs={}):
     # additional derivatives:
 
     try:
-        argspec = inspect.getfullargspec(f)
+        argspec = getargspec(f)
     except TypeError:
         # Some functions do not provide meta-data about their
         # arguments (see PEP 362). One cannot use keyword arguments

--- a/uncertainties/core.py
+++ b/uncertainties/core.py
@@ -531,7 +531,7 @@ def wrap(f, derivatives_args=[], derivatives_kwargs={}):
     # additional derivatives:
 
     try:
-        argspec = inspect.getargspec(f)
+        argspec = inspect.getfullargspec(f)
     except TypeError:
         # Some functions do not provide meta-data about their
         # arguments (see PEP 362). One cannot use keyword arguments


### PR DESCRIPTION
Some background: We are using this package extensively in a [gamma-ray spectroscopy package](https://github.com/lbl-anp/becquerel) and run into these warnings a lot during testing on `py36`.

As noted in #60, `inspect.getargspec` is deprecated in `py35` and onward. This short PR patches this warning for `py27` and `py36` onward (see [this doc](https://docs.python.org/3.6/library/inspect.html#inspect.getfullargspec) regarding reverting the `DeprecationWarning` between `py35` and `py36`). Additionally, the `inspect.signature` module was added in `py33`.