### PR TITLE
Workaround for getting numpy.linalg.pinv argument default with numpy 1.17

### DIFF
--- a/uncertainties/unumpy/core.py
+++ b/uncertainties/unumpy/core.py
@@ -532,7 +532,13 @@ def pinv_with_derivatives(arr, input_type, derivatives, rcond):
         yield term1+term2+term3
 
 # Default rcond argument for the generalization of numpy.linalg.pinv:
-pinv_default = numpy.linalg.pinv.__defaults__[0]  # Python 1, 2.6+:
+try:
+    pinv_default = numpy.linalg.pinv.__defaults__[0]  # Python 1, 2.6+:
+except TypeError:
+    # In numpy 1.17+, pinv is wrapped using a decorator which unfortunately
+    # results in the metadata (argument defaults) being lost. However, we can
+    # still get at the original function using the __wrapped__ attribute.
+    pinv_default = numpy.linalg.pinv.__wrapped__.__defaults__[0]
 
 pinv_with_uncert = func_with_deriv_to_uncert_func(pinv_with_derivatives)
 

--- a/uncertainties/unumpy/test_unumpy.py
+++ b/uncertainties/unumpy/test_unumpy.py
@@ -62,8 +62,11 @@ def test_numpy():
     # Equivalent with an array of AffineScalarFunc objects:
     try:
         numpy.exp(arr + ufloat(0, 0))
-    except AttributeError:
-        pass  # ! This is usual (but could be avoided)
+    except (AttributeError, TypeError):
+        # In numpy<1.17, an AttributeError is raised in this situation. This was
+        # considered a bug however, and in numpy 1.17 it was changed to a
+        # TypeError (see PR #12700 in numpy repository)
+        pass
     else:
         raise Exception("numpy.exp unexpectedly worked")
 


### PR DESCRIPTION
This PR is one possible workaround for #89. I've confirmed locally that it does work in conjunction with numpy 1.17 installed from PyPI.