### PR TITLE
Add enclosing round bracket flags r and R to the format_num method

### DIFF
--- a/doc/user_guide.rst
+++ b/doc/user_guide.rst
@@ -493,6 +493,24 @@ formatting options. They can be added at the end of the format string:
   >>> print '{:L}'.format(x*1e7)  # Automatic exponent form, LaTeX
   \left(2.00 \pm 0.10\right) \times 10^{6}
 
+- ``b`` for surrounding **brackets** (common exponent outside)
+
+	>>> print '{:b}'.format(x)
+	(2.00+/-0.10)e-01
+
+- ``B`` for surrounding **brackets** (common exponent inside)
+
+	>>> print '{:B}'.format(x)
+	((2.0+/-0.10)e-01)
+
+The ``b`` and ``B`` options can be useful when dealing with units:
+
+  >>> print '{:Pb} m'.format(x)
+	(2.00±0.10)×10⁻¹ m
+
+	>>> print '{:Pb} dm'.format(10 * x)
+	(2.00±0.10) dm
+
 These custom formatting options **can be combined** (when meaningful).
 
 Details

--- a/uncertainties/core.py
+++ b/uncertainties/core.py
@@ -1069,7 +1069,10 @@ def format_num(nom_val_main, error_main, common_exp,
     and the error, superscript exponents, etc.). "L" is for a LaTeX
     output. Options can be combined. "%" adds a final percent sign,
     and parentheses if the shorthand notation is not used. The P
-    option has priority over the L option (if both are given).
+    option has priority over the L option (if both are given). The "b"
+    option adds enclosing parenthesis with a common factor outside. "B"
+    forces the parenthesis to also enclose the factor, which means that
+    you might get two pairs of parenthesis.
     '''
 
     # print (nom_val_main, error_main, common_exp,
@@ -1427,11 +1430,16 @@ def format_num(nom_val_main, error_main, common_exp,
                 nom_val_str, pm_symbol, error_str,
                 RIGHT_GROUPING,
                 exp_str, percent_str))
+            if 'B' in options:
+                value_str = LEFT_GROUPING + value_str + RIGHT_GROUPING
         else:
             value_str = ''.join([nom_val_str, pm_symbol, error_str])
             if percent_str:
                 value_str = ''.join((
                     LEFT_GROUPING, value_str, RIGHT_GROUPING, percent_str))
+            if 'b' in options or 'B' in options:
+                value_str = ''.join((
+                    LEFT_GROUPING, value_str, RIGHT_GROUPING))
 
     return value_str
 
@@ -1926,6 +1934,9 @@ class AffineScalarFunc(object):
         mode is activated: "±" separates the nominal value from the
         standard deviation, exponents use superscript characters,
         etc. When "L" is present, the output is formatted with LaTeX.
+        The option "b" enforces surrounding brackets, but a common
+        factor will still be outside of the parenthesis. To have
+        a pair of parenthesis enclose everything, use "B".
 
         An uncertainty which is exactly zero is represented as the
         integer 0 (i.e. with no decimal point).
@@ -1964,7 +1975,7 @@ class AffineScalarFunc(object):
             (?P<uncert_prec>u?)  # Precision for the uncertainty?
             # The type can be omitted. Options must not go here:
             (?P<type>[eEfFgG%]??)  # n not supported
-            (?P<options>[LSP]*)$''',
+            (?P<options>[LSPbB]*)$''',
             format_spec,
             re.VERBOSE)
 

--- a/uncertainties/core.py
+++ b/uncertainties/core.py
@@ -1731,6 +1731,9 @@ class AffineScalarFunc(object):
         # vector of that space):
         return self != 0.  # Uses the AffineScalarFunc.__ne__ function
 
+    if sys.version_info < (3, 0):
+        __nonzero__ = __bool__
+
     ########################################
 
     ## Logical operators: warning: the resulting value cannot always

--- a/uncertainties/core.py
+++ b/uncertainties/core.py
@@ -1084,8 +1084,8 @@ def format_num(nom_val_main, error_main, common_exp,
     and the error, superscript exponents, etc.). "L" is for a LaTeX
     output. Options can be combined. "%" adds a final percent sign,
     and parentheses if the shorthand notation is not used. The P
-    option has priority over the L option (if both are given). The "b"
-    option adds enclosing parenthesis with a common factor outside. "B"
+    option has priority over the L option (if both are given). The "r"
+    option adds enclosing parenthesis with a common factor outside. "R"
     forces the parenthesis to also enclose the factor, which means that
     you might get two pairs of parenthesis.
     '''
@@ -1445,14 +1445,14 @@ def format_num(nom_val_main, error_main, common_exp,
                 nom_val_str, pm_symbol, error_str,
                 RIGHT_GROUPING,
                 exp_str, percent_str))
-            if 'B' in options:
+            if 'R' in options:
                 value_str = LEFT_GROUPING + value_str + RIGHT_GROUPING
         else:
             value_str = u''.join([nom_val_str, pm_symbol, error_str])
             if percent_str:
                 value_str = u''.join((
                     LEFT_GROUPING, value_str, RIGHT_GROUPING, percent_str))
-            if 'b' in options or 'B' in options:
+            if 'r' in options or 'R' in options:
                 value_str = u''.join((LEFT_GROUPING, value_str, RIGHT_GROUPING))
 
     return value_str
@@ -1951,9 +1951,9 @@ class AffineScalarFunc(object):
         mode is activated: "±" separates the nominal value from the
         standard deviation, exponents use superscript characters,
         etc. When "L" is present, the output is formatted with LaTeX.
-        The option "b" enforces surrounding brackets, but a common
+        The option "r" enforces surrounding brackets, but a common
         factor will still be outside of the parenthesis. To have
-        a pair of parenthesis enclose everything, use "B".
+        a pair of parenthesis enclose everything, use "R".
 
         An uncertainty which is exactly zero is represented as the
         integer 0 (i.e. with no decimal point).
@@ -1992,7 +1992,7 @@ class AffineScalarFunc(object):
             (?P<uncert_prec>u?)  # Precision for the uncertainty?
             # The type can be omitted. Options must not go here:
             (?P<type>[eEfFgG%]??)  # n not supported
-            (?P<options>[LSPbB]*)$''',
+            (?P<options>[LSPrR]*)$''',
             format_spec,
             re.VERBOSE)
 

--- a/uncertainties/core.py
+++ b/uncertainties/core.py
@@ -3195,6 +3195,8 @@ def ufloat_fromstr(representation, tag=None):
     the uncertainty signals an absolute uncertainty (instead of an
     uncertainty on the last digits of the nominal value).
     """
+    if representation.startswith('(') and representation.endswith(')'):
+        representation = representation[1:-1]
 
     (nominal_value, std_dev) = str_to_number_with_uncert(
         representation.strip())

--- a/uncertainties/core.py
+++ b/uncertainties/core.py
@@ -981,8 +981,16 @@ TO_SUPERSCRIPT = {
 # Inverted TO_SUPERSCRIPT table, for use with unicode.translate():
 #
 #! Python 2.7+ can use a dictionary comprehension instead:
-FROM_SUPERSCRIPT = {
-    ord(sup): normal for (normal, sup) in TO_SUPERSCRIPT.items()}
+if sys.version_info > (3, 0):
+    # all strings are unicode strings.
+    FROM_SUPERSCRIPT = {ord(sup): normal
+                        for (normal, sup) in TO_SUPERSCRIPT.items()}
+else:
+    # we need to decode the utf-8 strings first, before ord can find
+    # the code point for us.
+    FROM_SUPERSCRIPT = {ord(unicode(sup, 'utf-8')): normal
+                        for (normal, sup) in TO_SUPERSCRIPT.items()}
+
 
 def to_superscript(value):
     '''

--- a/uncertainties/core.py
+++ b/uncertainties/core.py
@@ -1011,7 +1011,10 @@ def from_superscript(number_str):
 
     number_str -- basestring object.
     '''
-    return int(str(number_str).translate(FROM_SUPERSCRIPT))
+    if sys.version > (3, 0):
+        return int(str(number_str).translate(FROM_SUPERSCRIPT))
+    else:
+        return int(unicode(str(number_str), 'utf-8').translate(FROM_SUPERSCRIPT))
 
 # Function that transforms an exponent produced by format_num() into
 # the corresponding string notation (for non-default modes):

--- a/uncertainties/core.py
+++ b/uncertainties/core.py
@@ -976,11 +976,14 @@ TO_SUPERSCRIPT = {
     0x37: '⁷',
     0x38: '⁸',
     0x39: '⁹'
-    }
+}
+if sys.version_info < (3, 0):
+    TO_SUPERSCRIPT = {normal: ord(unicode(sup, 'utf-8'))
+                      for (normal, sup) in TO_SUPERSCRIPT.items()}
 
 # Inverted TO_SUPERSCRIPT table, for use with unicode.translate():
 #
-#! Python 2.7+ can use a dictionary comprehension instead:
+# ! Python 2.7+ can use a dictionary comprehension instead:
 if sys.version_info > (3, 0):
     # all strings are unicode strings.
     FROM_SUPERSCRIPT = {ord(sup): normal
@@ -988,8 +991,9 @@ if sys.version_info > (3, 0):
 else:
     # we need to decode the utf-8 strings first, before ord can find
     # the code point for us.
-    FROM_SUPERSCRIPT = {ord(unicode(sup, 'utf-8')): normal
+    FROM_SUPERSCRIPT = {sup: normal
                         for (normal, sup) in TO_SUPERSCRIPT.items()}
+
 
 
 def to_superscript(value):
@@ -1000,8 +1004,7 @@ def to_superscript(value):
 
     value -- integer.
     '''
-
-    return ('%d' % value).translate(TO_SUPERSCRIPT)
+    return (u'%d' % value).translate(TO_SUPERSCRIPT)
 
 def from_superscript(number_str):
     '''
@@ -1011,7 +1014,8 @@ def from_superscript(number_str):
 
     number_str -- basestring object.
     '''
-    if sys.version > (3, 0):
+    # return int(str(number_str).translate(FROM_SUPERSCRIPT))
+    if sys.version_info > (3, 0):
         return int(str(number_str).translate(FROM_SUPERSCRIPT))
     else:
         return int(unicode(str(number_str), 'utf-8').translate(FROM_SUPERSCRIPT))
@@ -1019,7 +1023,7 @@ def from_superscript(number_str):
 # Function that transforms an exponent produced by format_num() into
 # the corresponding string notation (for non-default modes):
 EXP_PRINT = {
-    'pretty-print': lambda common_exp: '×10%s' % to_superscript(common_exp),
+    'pretty-print': lambda common_exp: u'×10%s' % to_superscript(common_exp),
     'latex': lambda common_exp: r' \times 10^{%d}' % common_exp}
 
 # Symbols used for grouping (typically between parentheses) in format_num():
@@ -1417,7 +1421,7 @@ def format_num(nom_val_main, error_main, common_exp,
         if 'P' in options:
             # Unicode has priority over LaTeX, so that users with a
             # Unicode-compatible LaTeX source can use ±:
-            pm_symbol = '±'
+            pm_symbol = u'±'
         elif 'L' in options:
             pm_symbol = r' \pm '
         else:
@@ -1436,7 +1440,7 @@ def format_num(nom_val_main, error_main, common_exp,
         # percent sign handling because this sign may too need
         # parentheses.
         if any_exp_factored and common_exp is not None:
-            value_str = ''.join((
+            value_str = u''.join((
                 LEFT_GROUPING,
                 nom_val_str, pm_symbol, error_str,
                 RIGHT_GROUPING,
@@ -1444,13 +1448,12 @@ def format_num(nom_val_main, error_main, common_exp,
             if 'B' in options:
                 value_str = LEFT_GROUPING + value_str + RIGHT_GROUPING
         else:
-            value_str = ''.join([nom_val_str, pm_symbol, error_str])
+            value_str = u''.join([nom_val_str, pm_symbol, error_str])
             if percent_str:
-                value_str = ''.join((
+                value_str = u''.join((
                     LEFT_GROUPING, value_str, RIGHT_GROUPING, percent_str))
             if 'b' in options or 'B' in options:
-                value_str = ''.join((
-                    LEFT_GROUPING, value_str, RIGHT_GROUPING))
+                value_str = u''.join((LEFT_GROUPING, value_str, RIGHT_GROUPING))
 
     return value_str
 
@@ -2969,7 +2972,7 @@ NUMBER_WITH_UNCERT_GLOBAL_EXP_RE_MATCH = re.compile(r'''
     \(
     (?P<simple_num_with_uncert>.*)
     \)
-    (?:[eE]|\s*×\s*10) (?P<exp_value>.*)
+    (?:[eE]|\s*×\s*10)(?P<exp_value>.*)
     $''', re.VERBOSE).match
 
 class NotParenUncert(ValueError):
@@ -3037,7 +3040,7 @@ def parse_error_in_parentheses(representation):
     return (value, uncert_value)
 
 # Regexp for catching the two variable parts of -1.2×10⁻¹²:
-PRETTY_PRINT_MATCH = re.compile(r'(.*?)\s*×\s*10(.*)').match
+PRETTY_PRINT_MATCH = re.compile('(.*?)\s*×\s*10(.*)').match
 
 def to_float(value_str):
     '''
@@ -3116,7 +3119,6 @@ def str_to_number_with_uncert(representation):
 
     match = re.match(r'(.*)(?:\+/-|±)(.*)', representation)
     if match:
-
         (nom_value, uncert) = match.groups()
 
         try:

--- a/uncertainties/test_uncertainties.py
+++ b/uncertainties/test_uncertainties.py
@@ -2039,7 +2039,7 @@ def test_format():
 
         for (format_spec, result) in representations.items():
 
-            print "FORMATTING {} WITH '{}'".format(repr(value), format_spec)
+            # print "FORMATTING {} WITH '{}'".format(repr(value), format_spec)
 
             # Jython 2.5.2 does not always represent NaN as nan or NAN
             # in the CPython way: for example, '%.2g' % float('nan')
@@ -2084,8 +2084,8 @@ def test_format():
 
                 # The original number and the new one should be consistent
                 # with each other:
-                print(' Checking for consistency: %r ~> %r ~> %r'
-                      % (value, representation, value_back))
+                # print(' Checking for consistency: %r ~> %r ~> %r'
+                #       % (value, representation, value_back))
                 try:
 
                     # The nominal value can be rounded to 0 when the

--- a/uncertainties/test_uncertainties.py
+++ b/uncertainties/test_uncertainties.py
@@ -1856,8 +1856,8 @@ def test_format():
             '13.6g': '  1.20000e-34+/-  0.00000e-34',
             '13.6G': '  1.20000E-34+/-  0.00000E-34',
             '.6GL': r'\left(1.20000 \pm 0.00000\right) \times 10^{-34}',
-            '.6GLb': r'\left(1.20000 \pm 0.00000\right) \times 10^{-34}',
-            '.6GLB': r'\left(\left(1.20000 \pm 0.00000\right) \times 10^{-34}\right)',
+            '.6GLr': r'\left(1.20000 \pm 0.00000\right) \times 10^{-34}',
+            '.6GLR': r'\left(\left(1.20000 \pm 0.00000\right) \times 10^{-34}\right)',
         },
 
         (float('nan'), 100): {  # NaN *nominal value*
@@ -1914,13 +1914,13 @@ def test_format():
             '': 'inf+/-123456789.0',  # Similar to '{}'.format(123456789.)
             'g': '(inf+/-1.23457)e+08',  # Similar to '{:g}'.format(123456789.)
             '.1e': '(inf+/-1.2)e+08',
-            '.1eb': '(inf+/-1.2)e+08',
-            '.1eB': '((inf+/-1.2)e+08)',
+            '.1er': '(inf+/-1.2)e+08',
+            '.1eR': '((inf+/-1.2)e+08)',
             '.1E': '(%s+/-1.2)E+08' % Inf_EFG,
             '.1ue': '(inf+/-1)e+08',
             '.1ueL': r'\left(\infty \pm 1\right) \times 10^{8}',
-            '.1ueLb': r'\left(\infty \pm 1\right) \times 10^{8}',
-            '.1ueLB': r'\left(\left(\infty \pm 1\right) \times 10^{8}\right)',
+            '.1ueLr': r'\left(\infty \pm 1\right) \times 10^{8}',
+            '.1ueLR': r'\left(\left(\infty \pm 1\right) \times 10^{8}\right)',
             '10.1e': '       inf+/-   1.2e+08',
             '10.1eL': r'    \infty \pm 1.2 \times 10^{8}'
         },
@@ -1930,8 +1930,8 @@ def test_format():
             '.1E': '%s+/-%s' % (Inf_EFG, Inf_EFG),
             '.1ue': 'inf+/-inf',
             'EL': r'\infty \pm \infty',
-            'ELB': r'\left(\infty \pm \infty\right)',
-            'ELb': r'\left(\infty \pm \infty\right)',
+            'ELR': r'\left(\infty \pm \infty\right)',
+            'ELr': r'\left(\infty \pm \infty\right)',
         },
 
         # Like the tests for +infinity, but for -infinity:
@@ -1974,8 +1974,8 @@ def test_format():
         # with a non-zero uncertainty:
         (724.2, 26.4): {
             '': '724+/-26',
-            'b': '(724+/-26)',
-            'B': '(724+/-26)',
+            'r': '(724+/-26)',
+            'R': '(724+/-26)',
         },
         (724, 0): {
             '': '724.0+/-0'

--- a/uncertainties/test_uncertainties.py
+++ b/uncertainties/test_uncertainties.py
@@ -1855,7 +1855,9 @@ def test_format():
             '.6g': '(1.20000+/-0.00000)e-34',
             '13.6g': '  1.20000e-34+/-  0.00000e-34',
             '13.6G': '  1.20000E-34+/-  0.00000E-34',
-            '.6GL': r'\left(1.20000 \pm 0.00000\right) \times 10^{-34}'
+            '.6GL': r'\left(1.20000 \pm 0.00000\right) \times 10^{-34}',
+            '.6GLb': r'\left(1.20000 \pm 0.00000\right) \times 10^{-34}',
+            '.6GLB': r'\left(\left(1.20000 \pm 0.00000\right) \times 10^{-34}\right)',
         },
 
         (float('nan'), 100): {  # NaN *nominal value*
@@ -1912,9 +1914,13 @@ def test_format():
             '': 'inf+/-123456789.0',  # Similar to '{}'.format(123456789.)
             'g': '(inf+/-1.23457)e+08',  # Similar to '{:g}'.format(123456789.)
             '.1e': '(inf+/-1.2)e+08',
+            '.1eb': '(inf+/-1.2)e+08',
+            '.1eB': '((inf+/-1.2)e+08)',
             '.1E': '(%s+/-1.2)E+08' % Inf_EFG,
             '.1ue': '(inf+/-1)e+08',
             '.1ueL': r'\left(\infty \pm 1\right) \times 10^{8}',
+            '.1ueLb': r'\left(\infty \pm 1\right) \times 10^{8}',
+            '.1ueLB': r'\left(\left(\infty \pm 1\right) \times 10^{8}\right)',
             '10.1e': '       inf+/-   1.2e+08',
             '10.1eL': r'    \infty \pm 1.2 \times 10^{8}'
         },
@@ -1923,7 +1929,9 @@ def test_format():
             '.1e': 'inf+/-inf',
             '.1E': '%s+/-%s' % (Inf_EFG, Inf_EFG),
             '.1ue': 'inf+/-inf',
-            'EL': r'\infty \pm \infty'
+            'EL': r'\infty \pm \infty',
+            'ELB': r'\left(\infty \pm \infty\right)',
+            'ELb': r'\left(\infty \pm \infty\right)',
         },
 
         # Like the tests for +infinity, but for -infinity:
@@ -1965,7 +1973,9 @@ def test_format():
         # digit past the decimal point" for Python floats, but only
         # with a non-zero uncertainty:
         (724.2, 26.4): {
-            '': '724+/-26'
+            '': '724+/-26',
+            'b': '(724+/-26)',
+            'B': '(724+/-26)',
         },
         (724, 0): {
             '': '724.0+/-0'

--- a/uncertainties/unumpy/core.py
+++ b/uncertainties/unumpy/core.py
@@ -384,7 +384,7 @@ def func_with_deriv_to_uncert_func(func_with_derivatives):
         for element in array_version.flat:
             # floats, etc. might be present
             if isinstance(element, uncert_core.AffineScalarFunc):
-                variables |= element.derivatives.keys()
+                variables |= set(element.derivatives.keys())
 
         array_nominal = nominal_values(array_version)
         # Function value, then derivatives at array_nominal (the


### PR DESCRIPTION
Implement a new formatting option, see #113.
Note: This doesn't work with unumpy arrays like regular formatting does not work with them, formatting in general does not work with them (regular numpy's fault?).