### PR TITLE
make changing the pretty-print times character easy

### DIFF
--- a/uncertainties/core.py
+++ b/uncertainties/core.py
@@ -1021,10 +1021,14 @@ def nrmlze_superscript(number_str):
     # a subclass of unicode, in Python 2):
     return int(str(number_str).translate(FROM_SUPERSCRIPT))
 
+# 'times'-symbol used for pretty-printing in the EXP_PRINT function below
+PRETTY_PRINT_TIMES = u'×'
+
 # Function that transforms an exponent produced by format_num() into
 # the corresponding string notation (for non-default modes):
 EXP_PRINT = {
-    'pretty-print': lambda common_exp: u'×10%s' % to_superscript(common_exp),
+    'pretty-print': lambda common_exp: u'%s10%s' % (
+        (PRETTY_PRINT_TIMES, to_superscript(common_exp))),
     'latex': lambda common_exp: r' \times 10^{%d}' % common_exp}
 
 # Symbols used for grouping (typically between parentheses) in format_num():


### PR DESCRIPTION
changing the × in pretty printing to me seems like it should be easy.
It's not hard now, but I had to get into the code. With this PR, it becomes:
```python
uncertainties.core.PRETTY_PRINT_TIMES = "⋅"
```

If you would take this PR, I guess the documentation should also mention it: currently it mentions that it's possible to change pretty printing, but not how. If not mentioned, it would be easy to do, but not easy to discover.